### PR TITLE
Clone into a path named after the repo by default

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,9 @@ inputs:
   persist-credentials:
     description: Passed directly to actions/checkout.
   path:
-    description: Passed directly to actions/checkout.
+    description: >
+      Like actions/checkout's path parameter, but defaults to the repository
+      name rather than the current working directory.
   clean:
     description: Passed directly to actions/checkout.
   fetch-depth:
@@ -40,9 +42,9 @@ runs:
   using: composite
   steps:
 
-  - run: "bash $GITHUB_ACTION_PATH/find-ref.sh"
-    id: find-ref
+  - id: find-ref
     shell: bash
+    run: "bash $GITHUB_ACTION_PATH/find-ref.sh"
     env:
       PR_BRANCH: ${{ github.base_ref }}
       CURRENT_REF: ${{ github.ref }}
@@ -51,6 +53,18 @@ runs:
       REPO: ${{ inputs.repo }}
       TOKEN: ${{ inputs.token }}
       DEFAULT_REF: ${{ inputs.default-ref }}
+
+  - id: path
+    shell: bash
+    run: |
+      if [[ -z "$INPUT_PATH" ]]; then
+        echo "::set-output name=path::${REPO/*\//}"
+      else
+        echo "::set-output name=path::${INPUT_PATH}"
+      fi
+    env:
+      INPUT_PATH: ${{ inputs.path }}
+      REPO: ${{ inputs.repo }}
 
   - uses: actions/checkout@v2
     with:
@@ -61,7 +75,7 @@ runs:
       ssh-known-hosts: ${{ inputs.ssh-known-hosts }}
       ssh-strict: ${{ inputs.ssh-strict }}
       persist-credentials: ${{ inputs.persist-credentials }}
-      path: ${{ inputs.path }}
+      path: ${{ steps.path.outputs.path }}
       clean: ${{ inputs.clean }}
       fetch-depth: ${{ inputs.fetch-depth }}
       lfs: ${{ inputs.lfs }}

--- a/find-ref.sh
+++ b/find-ref.sh
@@ -3,10 +3,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-# Echoes the sass/sass Git ref that should be checked out for the current GitHub
-# Actions run. If we're running specs for a pull request which refers to a
-# sass/sass pull request, we'll run against the latter rather than sass/sass
-# main.
 if [ -z "$PR_BRANCH" ]; then
   # Remove the "refs/heads/" prefix
   current_branch="${CURRENT_REF/refs\/heads\//}"
@@ -31,6 +27,10 @@ echo "::group::Pull request body"
 echo "$PR_BODY"
 echo "::endgroup::"
 
+# Echoes the sass/sass Git ref that should be checked out for the current GitHub
+# Actions run. If we're running specs for a pull request which refers to a
+# sass/sass pull request, we'll run against the latter rather than sass/sass
+# main.
 echo "::group::Finding pull request reference"
 for link in "$(echo "$PR_BODY" | grep -Eo "${REPO}(#|/pull/)[0-9]+")"; do
   if [[ "$link" = *#* ]]; then


### PR DESCRIPTION
Otherwise, actions/checkout replaces the current repo which isn't what
anyone wants.