### PR TITLE
Address deprecation warnings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -61,9 +61,9 @@ runs:
     shell: bash
     run: |
       if [[ -z "$INPUT_PATH" ]]; then
-        echo "path=${REPO/*\//}" | tee -a "$GITHUB_OUTPUT"
+        echo "path=${REPO/*\//}" >> "$GITHUB_OUTPUT"
       else
-        echo "path=${INPUT_PATH}" | tee -a "$GITHUB_OUTPUT"
+        echo "path=${INPUT_PATH}" >> "$GITHUB_OUTPUT"
       fi
     env:
       INPUT_PATH: ${{ inputs.path }}

--- a/action.yaml
+++ b/action.yaml
@@ -61,9 +61,9 @@ runs:
     shell: bash
     run: |
       if [[ -z "$INPUT_PATH" ]]; then
-        echo "path=${REPO/*\//}" | tee --append "$GITHUB_OUTPUT"
+        echo "path=${REPO/*\//}" | tee -a "$GITHUB_OUTPUT"
       else
-        echo "path=${INPUT_PATH}" | tee --append "$GITHUB_OUTPUT"
+        echo "path=${INPUT_PATH}" | tee -a "$GITHUB_OUTPUT"
       fi
     env:
       INPUT_PATH: ${{ inputs.path }}

--- a/action.yaml
+++ b/action.yaml
@@ -61,15 +61,15 @@ runs:
     shell: bash
     run: |
       if [[ -z "$INPUT_PATH" ]]; then
-        echo "::set-output name=path::${REPO/*\//}"
+        echo "path=${REPO/*\//}" | tee --append "$GITHUB_OUTPUT"
       else
-        echo "::set-output name=path::${INPUT_PATH}"
+        echo "path=${INPUT_PATH}" | tee --append "$GITHUB_OUTPUT"
       fi
     env:
       INPUT_PATH: ${{ inputs.path }}
       REPO: ${{ inputs.repo }}
 
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v3
     if: steps.find-ref.outputs.skip == 'false'
     with:
       repository: ${{ inputs.repo }}

--- a/find-ref.sh
+++ b/find-ref.sh
@@ -31,8 +31,8 @@ if [ -z "$PR_BRANCH" ]; then
     echo "Not a pull request, using default ref $default"
   fi
 
-  echo "skip=$skip" | tee -a "$GITHUB_OUTPUT"
-  echo "ref=$default" | tee -a "$GITHUB_OUTPUT"
+  echo "skip=$skip" >> "$GITHUB_OUTPUT"
+  echo "ref=$default" >> "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -60,8 +60,8 @@ for link in "$(echo "$PR_BODY" | grep -Eo "${REPO}(#|/pull/)[0-9]+")"; do
   )"
   if [[ "$?" == 0 && "$(echo "$json" | jq .state -r)" == "open" ]]; then
     echo "Linked to pull request $number"
-    echo "skip=false" | tee -a "$GITHUB_OUTPUT"
-    echo "ref=refs/pull/$number/head" | tee -a "$GITHUB_OUTPUT"
+    echo "skip=false" >> "$GITHUB_OUTPUT"
+    echo "ref=refs/pull/$number/head" >> "$GITHUB_OUTPUT"
     exit 0
   else
     echo "$link isn't a pull request."
@@ -74,6 +74,6 @@ else
   echo "No linked pull request, using default ref $default"
 fi
 
-echo "skip=$skip" | tee -a "$GITHUB_OUTPUT"
-echo "ref=$default" | tee -a "$GITHUB_OUTPUT"
+echo "skip=$skip" >> "$GITHUB_OUTPUT"
+echo "ref=$default" >> "$GITHUB_OUTPUT"
 echo "::endgroup::"

--- a/find-ref.sh
+++ b/find-ref.sh
@@ -31,8 +31,8 @@ if [ -z "$PR_BRANCH" ]; then
     echo "Not a pull request, using default ref $default"
   fi
 
-  echo "::set-output name=skip::$skip"
-  echo "::set-output name=ref::$default"
+  echo "skip=$skip" | tee -a "$GITHUB_OUTPUT"
+  echo "ref=$default" | tee -a "$GITHUB_OUTPUT"
   exit 0
 fi
 
@@ -60,8 +60,8 @@ for link in "$(echo "$PR_BODY" | grep -Eo "${REPO}(#|/pull/)[0-9]+")"; do
   )"
   if [[ "$?" == 0 && "$(echo "$json" | jq .state -r)" == "open" ]]; then
     echo "Linked to pull request $number"
-    echo "::set-output name=skip::false"
-    echo "::set-output name=ref::refs/pull/$number/head"
+    echo "skip=false" | tee -a "$GITHUB_OUTPUT"
+    echo "ref=refs/pull/$number/head" | tee -a "$GITHUB_OUTPUT"
     exit 0
   else
     echo "$link isn't a pull request."
@@ -74,6 +74,6 @@ else
   echo "No linked pull request, using default ref $default"
 fi
 
-echo "::set-output name=skip::$skip"
-echo "::set-output name=ref::$default"
+echo "skip=$skip" | tee -a "$GITHUB_OUTPUT"
+echo "ref=$default" | tee -a "$GITHUB_OUTPUT"
 echo "::endgroup::"


### PR DESCRIPTION
This PR fixes the following warnings:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```