### PR TITLE
Don't delete the old tag in the release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - run: git tag -d $VERSION
       - run: git tag $VERSION
       - run: git push origin :$VERSION
       - run: git push --tag


### PR DESCRIPTION
`clone-linked-repo` doesn't fetch tags anyway, so this just fails.